### PR TITLE
Update GUI

### DIFF
--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -24,6 +24,11 @@
     -fx-opacity: 1;
 }
 
+.panel-title {
+    -fx-text-fill: #1d1d1d;
+    -fx-font-size: 12pt;
+}
+
 .text-field {
     -fx-font-size: 12pt;
     -fx-font-family: "Segoe UI Semibold";

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -10,7 +10,6 @@
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
-<?import javafx.scene.layout.HBox?>
 
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
          title="Address App" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
@@ -47,22 +46,19 @@
           </padding>
         </StackPane>
 
-        <!-- New HBox to hold both SupplierListPanel and ProductListPanel -->
-        <HBox VBox.vgrow="ALWAYS" spacing="10">
-          <VBox fx:id="supplierList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
-            <padding>
-              <Insets top="10" right="10" bottom="10" left="10" />
-            </padding>
-            <StackPane fx:id="supplierListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
-          </VBox>
-
-          <VBox fx:id="productList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
-            <padding>
-              <Insets top="10" right="10" bottom="10" left="10" />
-            </padding>
-            <StackPane fx:id="productListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
-          </VBox>
-        </HBox>
+        <VBox fx:id="supplierList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
+          <padding>
+            <Insets top="10" right="10" bottom="10" left="10" />
+          </padding>
+          <StackPane fx:id="supplierListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+        </VBox>
+        <!-- Product List Panel - Initially hidden -->
+        <VBox fx:id="productList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS" visible="false" managed="false">
+          <padding>
+            <Insets top="10" right="10" bottom="10" left="10" />
+          </padding>
+          <StackPane fx:id="productListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+        </VBox>
 
         <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
       </VBox>

--- a/src/main/resources/view/SupplierListPanel.fxml
+++ b/src/main/resources/view/SupplierListPanel.fxml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
 
 <VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+  <!-- Title Label -->
+  <Label text="Suppliers" styleClass="panel-title"/>
+  <!-- ListView for Suppliers -->
   <ListView fx:id="supplierListView" VBox.vgrow="ALWAYS" />
 </VBox>


### PR DESCRIPTION
Revert gui back to have only one panel: 
<img width="958" alt="image" src="https://github.com/user-attachments/assets/dd901444-e860-4dad-8b14-4e0e74006173">

Only suppliers will be shown initially.
productListPanelPlaceholder is not visible at the start. 
