### PR TITLE
Make Error Messages More Specific

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -15,7 +15,14 @@ import seedu.address.model.supplier.Supplier;
 public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
-    public static final String MESSAGE_EMPTY_INPUT = "Empty input! \n%1$s";
+    public static final String MESSAGE_UNEXPECTED_PREAMBLE = "Unexpected content before command arguments. \n%1$s";
+    public static final String MESSAGE_MISSING_REQUIRED_PREFIXES = "Missing required prefixes. \n%1$s";
+    public static final String MESSAGE_INVALID_SYNTAX = "Unexpected syntax found. \n"
+            + "Reason 1: An extra prefix has been used. Only the following prefixes are allowed: \n%1$s \n"
+            + "Reason 2: The character '/' is strictly reserved for prefixes and should not appear elsewhere "
+            + "in the command.\n "
+            + "Please remove any unnecessary prefixes and ensure that '/' is used only for valid prefixes.";
+
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_SUPPLIER_DISPLAYED_INDEX = "The supplier index provided is invalid";
     public static final String MESSAGE_INVALID_STOCK_LEVEL = "Stock Level should be a non-negative integer.";

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -15,6 +15,7 @@ import seedu.address.model.supplier.Supplier;
 public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
+    public static final String MESSAGE_EMPTY_INPUT = "Empty input! \n%1$s";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_SUPPLIER_DISPLAYED_INDEX = "The supplier index provided is invalid";
     public static final String MESSAGE_INVALID_STOCK_LEVEL = "Stock Level should be a non-negative integer.";

--- a/src/main/java/seedu/address/logic/commands/AddProductCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddProductCommand.java
@@ -1,6 +1,12 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MAX_STOCK_LEVEL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MIN_STOCK_LEVEL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_SUPPLIER_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STOCK_LEVEL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
@@ -14,8 +20,22 @@ import seedu.address.model.product.Product;
 public class AddProductCommand extends Command {
 
     public static final String COMMAND_WORD = CommandWords.ADD_PRODUCT_COMMAND;
-
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a product to InvenTrack. ";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a supplier to InvenTrack. "
+            + "Parameters: "
+            + PREFIX_NAME + "NAME "
+            + "[" + PREFIX_STOCK_LEVEL + "STOCK LEVEL] "
+            + "[" + PREFIX_MIN_STOCK_LEVEL + "MIN STOCK LEVEL] "
+            + "[" + PREFIX_MAX_STOCK_LEVEL + "MAX STOCK LEVEL] "
+            + "[" + PREFIX_PRODUCT_SUPPLIER_NAME + "SUPPLIER NAME] "
+            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_NAME + "apple "
+            + PREFIX_STOCK_LEVEL + "100 "
+            + PREFIX_MIN_STOCK_LEVEL + "10 "
+            + PREFIX_MAX_STOCK_LEVEL + "500 "
+            + PREFIX_PRODUCT_SUPPLIER_NAME + "FreshFarms "
+            + PREFIX_TAG + "new "
+            + PREFIX_TAG + "featured";
 
     public static final String MESSAGE_SUCCESS = "New product added: %1$s";
     public static final String MESSAGE_DUPLICATE_PRODUCT = "This product already exists.";

--- a/src/main/java/seedu/address/logic/commands/AddSupplierCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddSupplierCommand.java
@@ -20,7 +20,7 @@ public class AddSupplierCommand extends Command {
 
     public static final String COMMAND_WORD = CommandWords.ADD_SUPPLIER_COMMAND;
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a supplier to the address book. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a supplier to InvenTrack. "
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "

--- a/src/main/java/seedu/address/logic/commands/AssignProductCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignProductCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUPPLIER_NAME;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PRODUCTS;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_SUPPLIERS;
 
 import java.util.HashSet;
@@ -78,9 +79,14 @@ public class AssignProductCommand extends Command {
             throw new CommandException(MESSAGE_PRODUCT_ALREADY_ASSIGNED);
         }
 
-        // Create a new supplier with the updated product list
         Set<Product> updatedProductList = new HashSet<>(supplierToAssign.getProducts());
-        updatedProductList.add(productToAssign);
+        Product updatedProduct = new Product(
+                productToAssign.getName(),
+                productToAssign.getStockLevel(),
+                productToAssign.getTags()
+        );
+        updatedProduct.setSupplierName(supplierName);
+        updatedProductList.add(updatedProduct);
         Supplier updatedSupplier = new Supplier(
                 supplierToAssign.getName(),
                 supplierToAssign.getPhone(),
@@ -89,11 +95,11 @@ public class AssignProductCommand extends Command {
                 supplierToAssign.getTags(),
                 updatedProductList
         );
-        // Update the product to contain the supplierName too
-        productToAssign.setSupplierName(supplierName);
 
+        model.setProduct(productToAssign, updatedProduct);
         model.setSupplier(supplierToAssign, updatedSupplier);
         model.updateFilteredSupplierList(PREDICATE_SHOW_ALL_SUPPLIERS);
+        model.updateFilteredProductList(PREDICATE_SHOW_ALL_PRODUCTS);
         return new CommandResult(String.format(MESSAGE_SUCCESS, productToAssign.getName(), supplierToAssign.getName()));
     }
     @Override

--- a/src/main/java/seedu/address/logic/commands/UnassignProductCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnassignProductCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUPPLIER_NAME;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PRODUCTS;
 
 import java.util.HashSet;
 import java.util.List;
@@ -69,14 +70,18 @@ public class UnassignProductCommand extends Command {
         }
 
         updatedProductList.remove(productToUnassign);
-
-        productToUnassign.unsetSupplier();
-
+        Product updatedProduct = new Product(
+                productToUnassign.getName(),
+                productToUnassign.getStockLevel(),
+                productToUnassign.getTags()
+        );
         Supplier updatedSupplier = new Supplier(supplierToUnassign.getName(), supplierToUnassign.getPhone(),
                 supplierToUnassign.getEmail(), supplierToUnassign.getAddress(),
                 supplierToUnassign.getTags(), updatedProductList);
 
+        model.setProduct(productToUnassign, updatedProduct);
         model.setSupplier(supplierToUnassign, updatedSupplier);
+        model.updateFilteredProductList(PREDICATE_SHOW_ALL_PRODUCTS);
         model.updateFilteredSupplierList(Model.PREDICATE_SHOW_ALL_SUPPLIERS);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, productToUnassign.getName(),

--- a/src/main/java/seedu/address/logic/parser/AddProductCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddProductCommandParser.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MAX_STOCK_LEVEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MIN_STOCK_LEVEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -46,11 +45,7 @@ public class AddProductCommandParser implements Parser<AddProductCommand> {
                 PREFIX_PRODUCT_SUPPLIER_NAME,
                 PREFIX_TAG);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME)
-                || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(
-                    MESSAGE_INVALID_COMMAND_FORMAT, AddProductCommand.MESSAGE_USAGE));
-        }
+        ParserUtil.verifyInput(argMultimap, new Prefix[]{PREFIX_NAME}, AddProductCommand.MESSAGE_USAGE);
 
         // Ensure no duplicate prefixes are used
         argMultimap.verifyNoDuplicatePrefixesFor(

--- a/src/main/java/seedu/address/logic/parser/AddSupplierCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddSupplierCommandParser.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -34,11 +33,8 @@ public class AddSupplierCommandParser implements Parser<AddSupplierCommand> {
     public AddSupplierCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
-
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL)
-                || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddSupplierCommand.MESSAGE_USAGE));
-        }
+        ParserUtil.verifyInput(argMultimap, new Prefix[]{PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS},
+                AddSupplierCommand.MESSAGE_USAGE);
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import seedu.address.logic.Messages;
@@ -75,4 +76,11 @@ public class ArgumentMultimap {
             throw new ParseException(Messages.getErrorMessageForDuplicatePrefixes(duplicatedPrefixes));
         }
     }
+    /**
+     * Returns all prefixes present in the ArgumentMultimap.
+     */
+    public Set<Prefix> getAllPrefixes() {
+        return argMultimap.keySet();
+    }
+
 }

--- a/src/main/java/seedu/address/logic/parser/AssignProductCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AssignProductCommandParser.java
@@ -1,9 +1,14 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_EMPTY_INPUT;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUPPLIER_NAME;
 
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AssignProductCommand;
@@ -15,25 +20,67 @@ import seedu.address.model.supplier.Name;
  * Parses input arguments and creates a new AssignProductCommand object
  */
 public class AssignProductCommandParser implements Parser<AssignProductCommand> {
+    private static final Logger logger = Logger.getLogger(AssignProductCommandParser.class.getName());
+    private static final Set<Prefix> ALLOWED_PREFIXES = Set.of(PREFIX_PRODUCT_NAME, PREFIX_SUPPLIER_NAME);
     /**
      * Parses the given {@code String} of arguments in the context of the AssignProductCommand
      * and returns a AssignProductCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public AssignProductCommand parse(String args) throws ParseException {
+
+        if (args == null || args.trim().isEmpty()) {
+            throw new ParseException(MESSAGE_EMPTY_INPUT);
+        }
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_PRODUCT_NAME, PREFIX_SUPPLIER_NAME);
+        logAllPrefixes(argMultimap);
+        verifyInput(argMultimap);
+        String productNameStr = argMultimap.getValue(PREFIX_PRODUCT_NAME).get();
+        String supplierNameStr = argMultimap.getValue(PREFIX_SUPPLIER_NAME).get();
 
+        ProductName productName = ParserUtil.parseProductName(productNameStr);
+        Name supplierName = ParserUtil.parseName(supplierNameStr);
+
+        return new AssignProductCommand(productName, supplierName);
+    }
+
+    private void verifyInput(ArgumentMultimap argMultimap) throws ParseException {
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PRODUCT_NAME, PREFIX_SUPPLIER_NAME);
+        // Unified error message for preamble content, missing prefixes, and extra prefixes
+        if (!argMultimap.getPreamble().isEmpty()
+                || !arePrefixesPresent(argMultimap, PREFIX_PRODUCT_NAME, PREFIX_SUPPLIER_NAME)
+                || hasExtraPrefixes(argMultimap, ALLOWED_PREFIXES)) {
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_PRODUCT_NAME, PREFIX_SUPPLIER_NAME)
-                || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AssignProductCommand.MESSAGE_USAGE));
         }
+    }
 
-        ProductName productName = ParserUtil.parseProductName(argMultimap.getValue(PREFIX_PRODUCT_NAME).get());
-        Name supplierName = ParserUtil.parseName(argMultimap.getValue(PREFIX_SUPPLIER_NAME).get());
-        return new AssignProductCommand(productName, supplierName);
+    private boolean hasExtraPrefixes(ArgumentMultimap argMultimap, Set<Prefix> allowedPrefixes) {
+        Set<Prefix> presentPrefixes = argMultimap.getAllPrefixes();
+
+        for (Prefix prefix : presentPrefixes) {
+            List<String> values = argMultimap.getAllValues(prefix);
+
+            // Check if any value contains an extra "/" which may indicate an extra prefix
+            for (String value : values) {
+                if (value.contains("/")) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Logs all prefixes found in the ArgumentMultimap along with their values.
+     */
+    private void logAllPrefixes(ArgumentMultimap argMultimap) {
+        Set<Prefix> prefixes = argMultimap.getAllPrefixes();
+        for (Prefix prefix : prefixes) {
+            String values = argMultimap.getAllValues(prefix).toString();
+            logger.log(Level.INFO, "Prefix: " + prefix.getPrefix() + " - Values: " + values);
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/AssignProductCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AssignProductCommandParser.java
@@ -1,15 +1,7 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_EMPTY_INPUT;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUPPLIER_NAME;
-
-import java.util.List;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AssignProductCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -20,22 +12,22 @@ import seedu.address.model.supplier.Name;
  * Parses input arguments and creates a new AssignProductCommand object
  */
 public class AssignProductCommandParser implements Parser<AssignProductCommand> {
-    private static final Logger logger = Logger.getLogger(AssignProductCommandParser.class.getName());
-    private static final Set<Prefix> ALLOWED_PREFIXES = Set.of(PREFIX_PRODUCT_NAME, PREFIX_SUPPLIER_NAME);
     /**
      * Parses the given {@code String} of arguments in the context of the AssignProductCommand
      * and returns a AssignProductCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public AssignProductCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_PRODUCT_NAME, PREFIX_SUPPLIER_NAME);
+        argMultimap.verifyNoDuplicatePrefixesFor(
+                PREFIX_PRODUCT_NAME,
+                PREFIX_SUPPLIER_NAME);
+        ParserUtil.verifyInput(argMultimap, new Prefix[]{PREFIX_PRODUCT_NAME, PREFIX_SUPPLIER_NAME},
+                AssignProductCommand.MESSAGE_USAGE);
 
-        if (args == null || args.trim().isEmpty()) {
-            throw new ParseException(MESSAGE_EMPTY_INPUT);
-        }
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_PRODUCT_NAME, PREFIX_SUPPLIER_NAME);
-        logAllPrefixes(argMultimap);
-        verifyInput(argMultimap);
+        argMultimap.verifyNoDuplicatePrefixesFor(
+                PREFIX_PRODUCT_NAME,
+                PREFIX_SUPPLIER_NAME);
         String productNameStr = argMultimap.getValue(PREFIX_PRODUCT_NAME).get();
         String supplierNameStr = argMultimap.getValue(PREFIX_SUPPLIER_NAME).get();
 
@@ -43,52 +35,6 @@ public class AssignProductCommandParser implements Parser<AssignProductCommand> 
         Name supplierName = ParserUtil.parseName(supplierNameStr);
 
         return new AssignProductCommand(productName, supplierName);
-    }
-
-    private void verifyInput(ArgumentMultimap argMultimap) throws ParseException {
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PRODUCT_NAME, PREFIX_SUPPLIER_NAME);
-        // Unified error message for preamble content, missing prefixes, and extra prefixes
-        if (!argMultimap.getPreamble().isEmpty()
-                || !arePrefixesPresent(argMultimap, PREFIX_PRODUCT_NAME, PREFIX_SUPPLIER_NAME)
-                || hasExtraPrefixes(argMultimap, ALLOWED_PREFIXES)) {
-
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AssignProductCommand.MESSAGE_USAGE));
-        }
-    }
-
-    private boolean hasExtraPrefixes(ArgumentMultimap argMultimap, Set<Prefix> allowedPrefixes) {
-        Set<Prefix> presentPrefixes = argMultimap.getAllPrefixes();
-
-        for (Prefix prefix : presentPrefixes) {
-            List<String> values = argMultimap.getAllValues(prefix);
-
-            // Check if any value contains an extra "/" which may indicate an extra prefix
-            for (String value : values) {
-                if (value.contains("/")) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Logs all prefixes found in the ArgumentMultimap along with their values.
-     */
-    private void logAllPrefixes(ArgumentMultimap argMultimap) {
-        Set<Prefix> prefixes = argMultimap.getAllPrefixes();
-        for (Prefix prefix : prefixes) {
-            String values = argMultimap.getAllValues(prefix).toString();
-            logger.log(Level.INFO, "Prefix: " + prefix.getPrefix() + " - Values: " + values);
-        }
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteProductCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteProductCommandParser.java
@@ -1,9 +1,6 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-
-import java.util.stream.Stream;
 
 import seedu.address.logic.commands.DeleteProductCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -22,23 +19,15 @@ public class DeleteProductCommandParser implements Parser<DeleteProductCommand> 
     public DeleteProductCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME);
-
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME) || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteProductCommand.MESSAGE_USAGE));
-        }
-
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME);
+        argMultimap.verifyNoDuplicatePrefixesFor(
+                PREFIX_NAME);
+        ParserUtil.verifyInput(argMultimap, new Prefix[]{PREFIX_NAME},
+                DeleteProductCommand.MESSAGE_USAGE);
+        argMultimap.verifyNoDuplicatePrefixesFor(
+                PREFIX_NAME);
         ProductName productName = ParserUtil.parseProductName(argMultimap.getValue(PREFIX_NAME).get());
 
         return new DeleteProductCommand(productName);
     }
 
-    /**
-     * Returns true if none of the prefixes contain empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes)
-                .allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteSupplierCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteSupplierCommandParser.java
@@ -1,9 +1,6 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-
-import java.util.stream.Stream;
 
 import seedu.address.logic.commands.DeleteSupplierCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -22,24 +19,14 @@ public class DeleteSupplierCommandParser implements Parser<DeleteSupplierCommand
     public DeleteSupplierCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME);
-
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME) || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    DeleteSupplierCommand.MESSAGE_USAGE));
-        }
-
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME);
+        argMultimap.verifyNoDuplicatePrefixesFor(
+                PREFIX_NAME);
+        ParserUtil.verifyInput(argMultimap, new Prefix[]{PREFIX_NAME},
+                DeleteSupplierCommand.MESSAGE_USAGE);
+        argMultimap.verifyNoDuplicatePrefixesFor(
+                PREFIX_NAME);
         Name supplierName = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
 
         return new DeleteSupplierCommand(supplierName);
-    }
-
-    /**
-     * Returns true if none of the prefixes contain empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes)
-                .allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/address/logic/parser/SetThresholdCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SetThresholdCommandParser.java
@@ -1,12 +1,9 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MAX_STOCK_LEVEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MIN_STOCK_LEVEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_NAME;
-
-import java.util.stream.Stream;
 
 import seedu.address.logic.commands.SetThresholdCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -35,12 +32,8 @@ public class SetThresholdCommandParser implements Parser<SetThresholdCommand> {
                         PREFIX_MIN_STOCK_LEVEL,
                         PREFIX_MAX_STOCK_LEVEL);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_PRODUCT_NAME)
-                || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(
-                    MESSAGE_INVALID_COMMAND_FORMAT, SetThresholdCommand.MESSAGE_USAGE));
-        }
-
+        ParserUtil.verifyInput(argMultimap, new Prefix[]{PREFIX_PRODUCT_NAME},
+                SetThresholdCommand.MESSAGE_USAGE);
         argMultimap.verifyNoDuplicatePrefixesFor(
                 PREFIX_PRODUCT_NAME,
                 PREFIX_MIN_STOCK_LEVEL,
@@ -95,14 +88,5 @@ public class SetThresholdCommandParser implements Parser<SetThresholdCommand> {
         } catch (NumberFormatException e) {
             throw new ParseException("Invalid stock level: " + errorMessage);
         }
-    }
-
-    /**
-     * Returns true if the specified prefixes contain non-empty values in the given {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(
-            ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes)
-                .allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/address/logic/parser/UnassignProductCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnassignProductCommandParser.java
@@ -1,10 +1,7 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUPPLIER_NAME;
-
-import java.util.stream.Stream;
 
 import seedu.address.logic.commands.UnassignProductCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -23,26 +20,15 @@ public class UnassignProductCommandParser implements Parser<UnassignProductComma
     public UnassignProductCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_PRODUCT_NAME, PREFIX_SUPPLIER_NAME);
-
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PRODUCT_NAME, PREFIX_SUPPLIER_NAME);
-
-        if (!arePrefixesPresent(argMultimap, PREFIX_PRODUCT_NAME, PREFIX_SUPPLIER_NAME)
-                || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    UnassignProductCommand.MESSAGE_USAGE));
-        }
-
+        ParserUtil.verifyInput(argMultimap, new Prefix[]{PREFIX_PRODUCT_NAME, PREFIX_SUPPLIER_NAME},
+                UnassignProductCommand.MESSAGE_USAGE);
+        argMultimap.verifyNoDuplicatePrefixesFor(
+                PREFIX_PRODUCT_NAME,
+                PREFIX_SUPPLIER_NAME);
         ProductName productName = ParserUtil.parseProductName(argMultimap.getValue(PREFIX_PRODUCT_NAME).get());
         Name supplierName = ParserUtil.parseName(argMultimap.getValue(PREFIX_SUPPLIER_NAME).get());
 
         return new UnassignProductCommand(productName, supplierName);
     }
 
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
 }

--- a/src/main/java/seedu/address/logic/parser/UpdateStockLevelCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UpdateStockLevelCommandParser.java
@@ -1,11 +1,8 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STOCK_LEVEL;
-
-import java.util.stream.Stream;
 
 import seedu.address.logic.commands.UpdateStockLevelCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -30,12 +27,8 @@ public class UpdateStockLevelCommandParser implements Parser<UpdateStockLevelCom
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_PRODUCT_NAME, PREFIX_STOCK_LEVEL);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_PRODUCT_NAME, PREFIX_STOCK_LEVEL)
-                || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    UpdateStockLevelCommand.MESSAGE_USAGE));
-        }
-
+        ParserUtil.verifyInput(argMultimap, new Prefix[]{PREFIX_PRODUCT_NAME, PREFIX_STOCK_LEVEL},
+                UpdateStockLevelCommand.MESSAGE_USAGE);
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PRODUCT_NAME, PREFIX_STOCK_LEVEL);
 
         ProductName productName = ParserUtil.parseProductName(argMultimap.getValue(PREFIX_PRODUCT_NAME).get());
@@ -43,14 +36,6 @@ public class UpdateStockLevelCommandParser implements Parser<UpdateStockLevelCom
         resultCurrentStock = parseCurrentStockLevelCommand(argMultimap, productName);
 
         return resultCurrentStock;
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
     private UpdateStockLevelCommand parseCurrentStockLevelCommand(ArgumentMultimap argMap, ProductName productName)

--- a/src/main/java/seedu/address/model/product/ProductName.java
+++ b/src/main/java/seedu/address/model/product/ProductName.java
@@ -8,6 +8,10 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
  */
 public class ProductName {
+    public static final String MESSAGE_EMPTY_NAME = "Supplier name cannot be blank.";
+
+    public static final String MESSAGE_NON_ALPHANUMERIC_NAME =
+            "Supplier names should only contain alphanumeric characters and spaces.";
     public static final String MESSAGE_CONSTRAINTS =
             "Names should only contain alphanumeric characters and spaces, and it should not be blank";
 

--- a/src/main/java/seedu/address/model/supplier/Address.java
+++ b/src/main/java/seedu/address/model/supplier/Address.java
@@ -9,13 +9,14 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Address {
 
-    public static final String MESSAGE_CONSTRAINTS = "Addresses can take any values, and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "Addresses can take any values, but should not be blank or contain"
+            + "'/' characters.";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[^\\s].*";
+    public static final String VALIDATION_REGEX = "^(?!\\s*$)(?!.*\\/).*";
 
     public final String value;
 

--- a/src/main/java/seedu/address/model/supplier/Name.java
+++ b/src/main/java/seedu/address/model/supplier/Name.java
@@ -8,7 +8,6 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
  */
 public class Name {
-
     public static final String MESSAGE_CONSTRAINTS =
             "Names should only contain alphanumeric characters and spaces, and it should not be blank";
 

--- a/src/test/java/seedu/address/logic/commands/AssignProductCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AssignProductCommandTest.java
@@ -37,8 +37,12 @@ public class AssignProductCommandTest {
 
         String expectedMessage = String.format(AssignProductCommand.MESSAGE_SUCCESS, VALID_PRODUCT_APPLE_PIE,
                 VALID_NAME_AMY);
+        Product updatedProduct = new ProductBuilder(product).withSupplierName(VALID_NAME_AMY).build();
+        Supplier updatedSupplier = new SupplierBuilder(supplier).withProducts(Set.of(updatedProduct)).build();
+
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setSupplier(supplier, new SupplierBuilder(supplier).withProducts(Set.of(product)).build());
+        expectedModel.setProduct(product, updatedProduct);
+        expectedModel.setSupplier(supplier, updatedSupplier);
 
         assertCommandSuccess(assignProductCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/parser/AddSupplierCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddSupplierCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_MISSING_REQUIRED_PREFIXES;
+import static seedu.address.logic.Messages.MESSAGE_UNEXPECTED_PREAMBLE;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
@@ -139,7 +140,7 @@ public class AddSupplierCommandParserTest {
 
     @Test
     public void parse_compulsoryFieldMissing_failure() {
-        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddSupplierCommand.MESSAGE_USAGE);
+        String expectedMessage = String.format(MESSAGE_MISSING_REQUIRED_PREFIXES, AddSupplierCommand.MESSAGE_USAGE);
 
         // missing name prefix
         assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
@@ -191,6 +192,6 @@ public class AddSupplierCommandParserTest {
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddSupplierCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_UNEXPECTED_PREAMBLE, AddSupplierCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AssignProductCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AssignProductCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_MISSING_REQUIRED_PREFIXES;
+import static seedu.address.logic.Messages.MESSAGE_UNEXPECTED_PREAMBLE;
 import static seedu.address.logic.commands.CommandTestUtil.PRODUCT_DESC_APPLE_PIE;
 import static seedu.address.logic.commands.CommandTestUtil.SUPPLIER_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
@@ -32,7 +33,7 @@ public class AssignProductCommandParserTest {
     public void parse_missingProductPrefix_failure() {
         // missing pr/ prefix
         String userInput = VALID_PRODUCT_APPLE_PIE + SUPPLIER_DESC_AMY;
-        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        assertParseFailure(parser, userInput, String.format(MESSAGE_MISSING_REQUIRED_PREFIXES,
                 AssignProductCommand.MESSAGE_USAGE));
     }
 
@@ -40,7 +41,7 @@ public class AssignProductCommandParserTest {
     public void parse_missingSupplierPrefix_failure() {
         // missing su/ prefix
         String userInput = PRODUCT_DESC_APPLE_PIE + VALID_NAME_AMY;
-        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        assertParseFailure(parser, userInput, String.format(MESSAGE_MISSING_REQUIRED_PREFIXES,
                 AssignProductCommand.MESSAGE_USAGE));
     }
 
@@ -48,7 +49,7 @@ public class AssignProductCommandParserTest {
     public void parse_missingBothPrefixes_failure() {
         // missing both pr/ and su/ prefixes
         String userInput = VALID_PRODUCT_APPLE_PIE + VALID_NAME_AMY;
-        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        assertParseFailure(parser, userInput, String.format(MESSAGE_MISSING_REQUIRED_PREFIXES,
                 AssignProductCommand.MESSAGE_USAGE));
     }
 
@@ -56,7 +57,7 @@ public class AssignProductCommandParserTest {
     public void parse_invalidPreamble_failure() {
         // preamble should not exist
         String userInput = "extra " + PRODUCT_DESC_APPLE_PIE + SUPPLIER_DESC_AMY;
-        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        assertParseFailure(parser, userInput, String.format(MESSAGE_UNEXPECTED_PREAMBLE,
                 AssignProductCommand.MESSAGE_USAGE));
     }
 

--- a/src/test/java/seedu/address/logic/parser/SetThresholdCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SetThresholdCommandParserTest.java
@@ -1,7 +1,8 @@
 package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_MISSING_REQUIRED_PREFIXES;
+import static seedu.address.logic.Messages.MESSAGE_UNEXPECTED_PREAMBLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MAX_STOCK_LEVEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MIN_STOCK_LEVEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_NAME;
@@ -56,7 +57,7 @@ public class SetThresholdCommandParserTest {
 
     @Test
     public void parse_compulsoryAndMissingField_failure() {
-        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        String expectedMessage = String.format(MESSAGE_MISSING_REQUIRED_PREFIXES,
                 SetThresholdCommand.MESSAGE_USAGE);
 
         // missing product name prefix
@@ -123,11 +124,11 @@ public class SetThresholdCommandParserTest {
     public void parse_invalidPreamble_failure() {
         // non-empty preamble
         assertParseFailure(parser, "some random string pr/Product1 min/50",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SetThresholdCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_UNEXPECTED_PREAMBLE, SetThresholdCommand.MESSAGE_USAGE));
 
         // preamble with numbers
         assertParseFailure(parser, "123 pr/Product1 min/50",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SetThresholdCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_UNEXPECTED_PREAMBLE, SetThresholdCommand.MESSAGE_USAGE));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/UnassignProductCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnassignProductCommandParserTest.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_MISSING_REQUIRED_PREFIXES;
 import static seedu.address.logic.Messages.MESSAGE_UNEXPECTED_PREAMBLE;
 import static seedu.address.logic.commands.CommandTestUtil.PRODUCT_DESC_APPLE_PIE;

--- a/src/test/java/seedu/address/logic/parser/UnassignProductCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnassignProductCommandParserTest.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_MISSING_REQUIRED_PREFIXES;
+import static seedu.address.logic.Messages.MESSAGE_UNEXPECTED_PREAMBLE;
 import static seedu.address.logic.commands.CommandTestUtil.PRODUCT_DESC_APPLE_PIE;
 import static seedu.address.logic.commands.CommandTestUtil.SUPPLIER_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
@@ -34,7 +36,7 @@ public class UnassignProductCommandParserTest {
     public void parse_missingProductPrefix_failure() {
         // missing pr/ prefix
         String userInput = VALID_PRODUCT_APPLE_PIE + SUPPLIER_DESC_AMY;
-        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        assertParseFailure(parser, userInput, String.format(MESSAGE_MISSING_REQUIRED_PREFIXES,
                 UnassignProductCommand.MESSAGE_USAGE));
     }
 
@@ -42,7 +44,7 @@ public class UnassignProductCommandParserTest {
     public void parse_missingSupplierPrefix_failure() {
         // missing su/ prefix
         String userInput = PRODUCT_DESC_APPLE_PIE + VALID_NAME_AMY;
-        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        assertParseFailure(parser, userInput, String.format(MESSAGE_MISSING_REQUIRED_PREFIXES,
                 UnassignProductCommand.MESSAGE_USAGE));
     }
 
@@ -50,7 +52,7 @@ public class UnassignProductCommandParserTest {
     public void parse_missingBothPrefixes_failure() {
         // missing both pr/ and su/ prefixes
         String userInput = VALID_PRODUCT_APPLE_PIE + VALID_NAME_AMY;
-        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        assertParseFailure(parser, userInput, String.format(MESSAGE_MISSING_REQUIRED_PREFIXES,
                 UnassignProductCommand.MESSAGE_USAGE));
     }
 
@@ -58,7 +60,7 @@ public class UnassignProductCommandParserTest {
     public void parse_invalidPreamble_failure() {
         // preamble should not exist
         String userInput = "extra " + PRODUCT_DESC_APPLE_PIE + SUPPLIER_DESC_AMY;
-        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        assertParseFailure(parser, userInput, String.format(MESSAGE_UNEXPECTED_PREAMBLE,
                 UnassignProductCommand.MESSAGE_USAGE));
     }
 

--- a/src/test/java/seedu/address/logic/parser/UpdateStockLevelCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UpdateStockLevelCommandParserTest.java
@@ -3,6 +3,8 @@ package seedu.address.logic.parser;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_STOCK_LEVEL;
+import static seedu.address.logic.Messages.MESSAGE_MISSING_REQUIRED_PREFIXES;
+import static seedu.address.logic.Messages.MESSAGE_UNEXPECTED_PREAMBLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STOCK_LEVEL;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -44,7 +46,7 @@ public class UpdateStockLevelCommandParserTest {
 
     @Test
     public void parse_compulsoryFieldMissing_failure() {
-        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        String expectedMessage = String.format(MESSAGE_MISSING_REQUIRED_PREFIXES,
                 UpdateStockLevelCommand.MESSAGE_USAGE);
 
         // missing product name prefix
@@ -92,11 +94,11 @@ public class UpdateStockLevelCommandParserTest {
     public void parse_invalidPreamble_failure() {
         // non-empty preamble
         assertParseFailure(parser, "some random string pr/Product1 stk/1000",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, UpdateStockLevelCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_UNEXPECTED_PREAMBLE, UpdateStockLevelCommand.MESSAGE_USAGE));
 
         // preamble with numbers
         assertParseFailure(parser, "123 pr/Product1 stk/1000",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, UpdateStockLevelCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_UNEXPECTED_PREAMBLE, UpdateStockLevelCommand.MESSAGE_USAGE));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/UpdateStockLevelCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UpdateStockLevelCommandParserTest.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_STOCK_LEVEL;
 import static seedu.address.logic.Messages.MESSAGE_MISSING_REQUIRED_PREFIXES;
 import static seedu.address.logic.Messages.MESSAGE_UNEXPECTED_PREAMBLE;

--- a/src/test/java/seedu/address/model/supplier/AddressTest.java
+++ b/src/test/java/seedu/address/model/supplier/AddressTest.java
@@ -26,7 +26,8 @@ public class AddressTest {
 
         // invalid addresses
         assertFalse(Address.isValidAddress("")); // empty string
-        assertFalse(Address.isValidAddress(" ")); // spaces only
+        assertFalse(Address.isValidAddress("  ")); // spaces only
+        assertFalse(Address.isValidAddress("Blk 456, Den Road, #01-355//"));
 
         // valid addresses
         assertTrue(Address.isValidAddress("Blk 456, Den Road, #01-355"));


### PR DESCRIPTION
Made error messages **more specific for all command parsers except view_product and view_supplier**
Added: 
MESSAGE_UNEXPECTED_PREAMBLE
MESSAGE_MISSING_REQUIRED_PREFIXES
MESSAGE_INVALID_SYNTAX
in **Message.java**

**Disallowed the use of "/" in all inputs (specifically in Address)**
**Reason:** The user might not know the command prefixes and add an extra prefix, in this case, InvenTrack should warn the user of the extra prefix. Refer to #121, #126 and #128 