### PR TITLE
Fix bugs with trailing spaces and case sensitivity

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AutoCompleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AutoCompleteCommand.java
@@ -54,7 +54,7 @@ public class AutoCompleteCommand extends Command {
         } else if (inputType.equals(PREFIX_PRODUCT_NAME)) {
             possibleCompletions = model.getFilteredProductList().stream()
                     .map(Product::getName)
-                    .map(name -> name.fullName)
+                    .map(name -> name.getOriginalName())
                     .collect(Collectors.toList());
         } else if (inputType.equals(PREFIX_TAG)) {
             Set<String> tagSet = new HashSet<>();

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -53,8 +53,9 @@ public class ParserUtil {
         if (!Name.isValidName(trimmedName)) {
             throw new ParseException(Name.MESSAGE_CONSTRAINTS);
         }
-        return new Name(trimmedName);
+        return new Name(name);
     }
+
 
     /**
      * Parses a {@code String name} into a {@code Name}.
@@ -68,7 +69,7 @@ public class ParserUtil {
         if (!ProductName.isValidName(trimmedName)) {
             throw new ParseException(Name.MESSAGE_CONSTRAINTS);
         }
-        return new ProductName(trimmedName);
+        return new ProductName(name);
     }
 
     /**

--- a/src/main/java/seedu/address/model/product/ProductName.java
+++ b/src/main/java/seedu/address/model/product/ProductName.java
@@ -1,7 +1,6 @@
 package seedu.address.model.product;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
  * Represents a Product's name in the address book.
@@ -21,7 +20,8 @@ public class ProductName {
      */
     public static final String VALIDATION_REGEX = "[^/][^/]*";
 
-    public final String fullName;
+    private final String originalName;
+    private final String normalizedName;
 
     /**
      * Constructs a {@code Name}.
@@ -30,8 +30,16 @@ public class ProductName {
      */
     public ProductName(String name) {
         requireNonNull(name);
-        checkArgument(isValidName(name), MESSAGE_CONSTRAINTS);
-        fullName = name;
+
+        // Store the original name as provided by the user
+        originalName = name.trim().replaceAll("\\s+", " ");
+
+        // Normalize the name for internal use (lowercase)
+        normalizedName = originalName.toLowerCase();
+
+        if (!isValidName(normalizedName)) {
+            throw new IllegalArgumentException(MESSAGE_CONSTRAINTS);
+        }
     }
 
     /**
@@ -41,30 +49,29 @@ public class ProductName {
         return test.matches(VALIDATION_REGEX);
     }
 
+    public String getOriginalName() {
+        return originalName;
+    }
 
-    @Override
-    public String toString() {
-        return fullName;
+    public String getNormalizedName() {
+        return normalizedName;
     }
 
     @Override
     public boolean equals(Object other) {
-        if (other == this) {
-            return true;
-        }
-
-        // instanceof handles nulls
-        if (!(other instanceof seedu.address.model.product.ProductName)) {
-            return false;
-        }
-
-        seedu.address.model.product.ProductName otherName = (seedu.address.model.product.ProductName) other;
-        return fullName.equals(otherName.fullName);
+        return other == this // short circuit if same object
+                || (other instanceof ProductName // instanceof handles nulls
+                && normalizedName.equals(((ProductName) other).normalizedName));
     }
 
     @Override
     public int hashCode() {
-        return fullName.hashCode();
+        return normalizedName.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return originalName;
     }
 
 }

--- a/src/main/java/seedu/address/model/product/ProductNameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/product/ProductNameContainsKeywordsPredicate.java
@@ -18,7 +18,7 @@ public class ProductNameContainsKeywordsPredicate implements Predicate<Product> 
     @Override
     public boolean test(Product product) {
         return keywords.stream()
-                .anyMatch(keyword -> product.getName().fullName.toLowerCase().contains(keyword.toLowerCase()));
+                .anyMatch(keyword -> product.getName().getNormalizedName().contains(keyword.toLowerCase()));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/supplier/EmptyName.java
+++ b/src/main/java/seedu/address/model/supplier/EmptyName.java
@@ -1,0 +1,37 @@
+package seedu.address.model.supplier;
+
+/**
+ * Represents an empty supplier name when no supplier is yet assigned.
+ */
+public class EmptyName extends Name {
+    /**
+     * Constructs an {@code EmptyName} instance representing the absence of a supplier.
+     */
+    public EmptyName() {
+        super("No Supplier Assigned");
+    }
+
+    /**
+     * Returns a string representation indicating no supplier is assigned.
+     */
+    @Override
+    public String toString() {
+        return "No Supplier Assigned";
+    }
+
+    /**
+     * Overrides equals to ensure that all EmptyName instances are considered equal.
+     */
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof EmptyName;
+    }
+
+    /**
+     * Overrides hashCode to be consistent with equals.
+     */
+    @Override
+    public int hashCode() {
+        return toString().hashCode();
+    }
+}

--- a/src/main/java/seedu/address/model/supplier/Name.java
+++ b/src/main/java/seedu/address/model/supplier/Name.java
@@ -1,7 +1,6 @@
 package seedu.address.model.supplier;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
  * Represents a Supplier's name in the address book.
@@ -18,6 +17,7 @@ public class Name {
     public static final String VALIDATION_REGEX = "[^/][^/]*";
 
     public final String fullName;
+    private final String normalizedName;
 
     /**
      * Constructs a {@code Name}.
@@ -26,8 +26,14 @@ public class Name {
      */
     public Name(String name) {
         requireNonNull(name);
-        checkArgument(isValidName(name), MESSAGE_CONSTRAINTS);
-        fullName = name;
+
+        fullName = name.trim().replaceAll("\\s+", " ");
+
+        normalizedName = fullName.toLowerCase();
+
+        if (!isValidName(name)) {
+            throw new IllegalArgumentException(MESSAGE_CONSTRAINTS);
+        }
     }
 
     /**
@@ -37,30 +43,24 @@ public class Name {
         return test.matches(VALIDATION_REGEX);
     }
 
+    public String getNormalizedName() {
+        return normalizedName;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this
+                || (other instanceof Name
+                && normalizedName.equals(((Name) other).normalizedName));
+    }
+
+    @Override
+    public int hashCode() {
+        return normalizedName.hashCode();
+    }
 
     @Override
     public String toString() {
         return fullName;
     }
-
-    @Override
-    public boolean equals(Object other) {
-        if (other == this) {
-            return true;
-        }
-
-        // instanceof handles nulls
-        if (!(other instanceof Name)) {
-            return false;
-        }
-
-        Name otherName = (Name) other;
-        return fullName.equals(otherName.fullName);
-    }
-
-    @Override
-    public int hashCode() {
-        return fullName.hashCode();
-    }
-
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedProduct.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedProduct.java
@@ -53,7 +53,7 @@ class JsonAdaptedProduct {
      * Converts a given {@code Product} into this class for Jackson use.
      */
     public JsonAdaptedProduct(Product source) {
-        name = source.getName().fullName;
+        name = source.getName().getOriginalName();
         supplierName = source.getSupplierName() != null ? source.getSupplierName().fullName : "";
         StockLevel stock = source.getStockLevel();
         curStock = stock.getStockLevel();

--- a/src/test/java/seedu/address/logic/commands/AddProductCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddProductCommandParserTest.java
@@ -1,0 +1,35 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.model.product.ProductName;
+
+public class AddProductCommandParserTest {
+
+    @Test
+    public void parseProductName_whitespaceNormalization_success() throws Exception {
+        String inputName1 = "big banana";
+        String inputName2 = "big    banana";
+        ProductName productName1 = ParserUtil.parseProductName(inputName1);
+        ProductName productName2 = ParserUtil.parseProductName(inputName2);
+
+        assertEquals(productName1, productName2);
+        assertEquals("big banana", productName1.getOriginalName());
+    }
+
+    @Test
+    public void parseProductName_caseNormalization_success() throws Exception {
+        String inputName1 = "Apple";
+        String inputName2 = "apple";
+        ProductName productName1 = ParserUtil.parseProductName(inputName1);
+        ProductName productName2 = ParserUtil.parseProductName(inputName2);
+
+        assertEquals(productName1, productName2);
+        assertEquals("apple", productName1.getNormalizedName());
+        assertEquals("apple", productName2.getNormalizedName());
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/AddSupplierCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddSupplierCommandParserTest.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.model.supplier.Name;
+
+public class AddSupplierCommandParserTest {
+    @Test
+    public void parseName_whitespaceNormalization_success() throws Exception {
+        String inputName1 = "John Smith";
+        String inputName2 = "John    Smith";
+        Name name1 = ParserUtil.parseName(inputName1);
+        Name name2 = ParserUtil.parseName(inputName2);
+
+        assertEquals(name1, name2);
+        assertEquals("John Smith", name1.fullName);
+    }
+
+    @Test
+    public void parseSupplierName_caseNormalization_success() throws Exception {
+        String inputName1 = "John Doe";
+        String inputName2 = "johN   dOe";
+        Name supplierName1 = ParserUtil.parseName(inputName1);
+        Name supplierName2 = ParserUtil.parseName(inputName2);
+
+        assertEquals(supplierName1, supplierName2);
+        assertEquals("john doe", supplierName1.getNormalizedName());
+        assertEquals("john doe", supplierName2.getNormalizedName());
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/AutoCompleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AutoCompleteCommandTest.java
@@ -69,7 +69,7 @@ public class AutoCompleteCommandTest {
         AutoCompleteCommand autoCompleteCommand = new AutoCompleteCommand("",
             CliSyntax.PREFIX_PRODUCT_NAME.getPrefix());
         CommandResult result = autoCompleteCommand.execute(model);
-        List<String> expectedCompletions = Arrays.asList(apple.getName().fullName);
+        List<String> expectedCompletions = Arrays.asList(apple.getName().getOriginalName());
         assertEquals(String.join(AutoCompleteCommand.SUGGESTIONS_DELIMITER, expectedCompletions),
             result.getFeedbackToUser());
     }

--- a/src/test/java/seedu/address/model/supplier/SupplierTest.java
+++ b/src/test/java/seedu/address/model/supplier/SupplierTest.java
@@ -47,14 +47,13 @@ public class SupplierTest {
         editedAlice = new SupplierBuilder(ALICE).withName(VALID_NAME_BOB).build();
         assertFalse(ALICE.isSameSupplier(editedAlice));
 
-        // name differs in case, all other attributes same -> returns false
         Supplier editedBob = new SupplierBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSameSupplier(editedBob));
+        assertTrue(BOB.isSameSupplier(editedBob));
 
         // name has trailing spaces, all other attributes same -> returns false
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
         editedBob = new SupplierBuilder(BOB).withName(nameWithTrailingSpaces).build();
-        assertFalse(BOB.isSameSupplier(editedBob));
+        assertTrue(BOB.isSameSupplier(editedBob));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/ProductBuilder.java
+++ b/src/test/java/seedu/address/testutil/ProductBuilder.java
@@ -123,7 +123,7 @@ public class ProductBuilder {
             }
             return new Product(name, stockLevel, tags);
         } catch (InvalidStockLevelException | InvalidMinStockLevelException
-                | InvalidMaxStockLevelException | StockLevelOutOfBoundsException e) {
+                 | InvalidMaxStockLevelException | StockLevelOutOfBoundsException e) {
             // For testing purposes, wrap checked exceptions into unchecked exceptions
             throw new RuntimeException("Invalid stock levels set in ProductBuilder: " + e.getMessage(), e);
         }


### PR DESCRIPTION
Fixed problems that arose due to:

- Spaces were improperly trimmed (e.g. john doe and john    doe are treated as different)
- Names were case sensitive

Added testcases.