### PR TITLE
Fix add product command and unassign command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddProductCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddProductCommand.java
@@ -39,6 +39,7 @@ public class AddProductCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New product added: %1$s";
     public static final String MESSAGE_DUPLICATE_PRODUCT = "This product already exists.";
+    public static final String MESSAGE_SUPPLIER_NOT_FOUND = "Supplier not found: %1$s";
 
     private final Product toAdd;
 
@@ -53,19 +54,23 @@ public class AddProductCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-
         if (model.hasProduct(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_PRODUCT);
         }
-
+        // Check if the specified supplier exists
+        if (toAdd.getSupplierName() != null && model.findSupplier(toAdd.getSupplierName()) == null) {
+            throw new CommandException(
+                    String.format(MESSAGE_SUPPLIER_NOT_FOUND, toAdd.getSupplierName())
+            );
+        }
+        //Add product
         model.addProduct(toAdd);
-
-        if (toAdd.getSupplierName() != null) { // TODO: Inform user that AssignProduct gets called here too
+        //Assign supplier to product
+        if (toAdd.getSupplierName() != null) {
             AssignProductCommand assignProductCommand = new AssignProductCommand(toAdd.getName(),
                 toAdd.getSupplierName());
             assignProductCommand.execute(model);
         }
-
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/UnassignProductCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnassignProductCommand.java
@@ -32,7 +32,6 @@ public class UnassignProductCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Unassigned Product: %1$s to Supplier: %2$s";
     public static final String MESSAGE_PRODUCT_NOT_FOUND = "Product not found: %1$s";
     public static final String MESSAGE_PRODUCT_NOT_ASSIGNED = "Product was not assigned to the supplier initially.";
-
     private final ProductName productName;
 
     /**
@@ -67,7 +66,6 @@ public class UnassignProductCommand extends Command {
 
     private Supplier findSupplierWithProduct(Model model, Product product) throws CommandException {
         Name supplierName = product.getSupplierName();
-
         // Assertions to ensure consistency between supplier name and assignment status
         if (supplierName == null) {
             assert !model.isProductAssignedToAnySupplier(product)
@@ -76,7 +74,6 @@ public class UnassignProductCommand extends Command {
             assert model.isProductAssignedToAnySupplier(product)
                     : "Product with non-null supplier name should be assigned to a supplier";
         }
-
         // Check if the product is assigned to any supplier
         if (supplierName == null || !model.isProductAssignedToAnySupplier(product)) {
             throw new CommandException(MESSAGE_PRODUCT_NOT_ASSIGNED);

--- a/src/main/java/seedu/address/logic/parser/AddProductCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddProductCommandParser.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_SUPPLIER_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Set;
-import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddProductCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -117,15 +116,5 @@ public class AddProductCommandParser implements Parser<AddProductCommand> {
         } catch (NumberFormatException e) {
             throw new ParseException(MESSAGE_INVALID_STOCK_LEVEL);
         }
-    }
-
-    /**
-     * Returns true if the specified prefixes contain non-empty values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(
-            ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes)
-                .allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -134,5 +134,6 @@ public interface Model {
     Product findProductByName(ProductName productName);
 
     Supplier findSupplier(Name supplierName);
-}
 
+    boolean isProductAssignedToAnySupplier(Product product);
+}

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -174,6 +174,12 @@ public class ModelManager implements Model {
         return addressBook.findSupplier(supplierName);
     }
 
+    @Override
+    public boolean isProductAssignedToAnySupplier(Product product) {
+        return filteredSuppliers.stream()
+                .anyMatch(supplier -> supplier.getProducts().contains(product));
+    }
+
     //=========== Filtered/Sorted Supplier/Product List Accessors ===========
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/AddProductCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddProductCommandParserTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.model.product.ProductName;
+import seedu.address.model.supplier.Name;
 
 public class AddProductCommandParserTest {
 
@@ -32,4 +33,29 @@ public class AddProductCommandParserTest {
         assertEquals("apple", productName2.getNormalizedName());
     }
 
+    public static class AddSupplierCommandParserTest {
+        @Test
+        public void parseName_whitespaceNormalization_success() throws Exception {
+            String inputName1 = "John Smith";
+            String inputName2 = "John    Smith";
+            Name name1 = ParserUtil.parseName(inputName1);
+            Name name2 = ParserUtil.parseName(inputName2);
+
+            assertEquals(name1, name2);
+            assertEquals("John Smith", name1.fullName);
+        }
+
+        @Test
+        public void parseSupplierName_caseNormalization_success() throws Exception {
+            String inputName1 = "John Doe";
+            String inputName2 = "johN   dOe";
+            Name supplierName1 = ParserUtil.parseName(inputName1);
+            Name supplierName2 = ParserUtil.parseName(inputName2);
+
+            assertEquals(supplierName1, supplierName2);
+            assertEquals("john doe", supplierName1.getNormalizedName());
+            assertEquals("john doe", supplierName2.getNormalizedName());
+        }
+
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/AddProductCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddProductCommandTest.java
@@ -1,13 +1,19 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Predicate;
-import javafx.collections.ObservableList;
+
 import org.junit.jupiter.api.Test;
+
+import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -20,26 +26,18 @@ import seedu.address.model.supplier.Name;
 import seedu.address.model.supplier.Supplier;
 import seedu.address.testutil.ProductBuilder;
 
-import static java.util.Objects.requireNonNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.testutil.Assert.assertThrows;
-
 public class AddProductCommandTest {
-
     //null passed
     @Test
     public void constructor_nullProduct_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new AddProductCommand(null));
     }
-
     //Product does not exist and supplier exists initially
     @Test
     public void execute_productAcceptedByModel_addSuccessful() throws Exception {
         ModelStubAcceptingProductAdded modelStub = new ModelStubAcceptingProductAdded();
         Product validProduct = new ProductBuilder().build();
-
         CommandResult commandResult = new AddProductCommand(validProduct).execute(modelStub);
-
         assertEquals(String.format(AddProductCommand.MESSAGE_SUCCESS, Messages.format(validProduct)),
                 commandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(validProduct), modelStub.productsAdded);
@@ -50,7 +48,6 @@ public class AddProductCommandTest {
         Product validProduct = new ProductBuilder().build();
         AddProductCommand addProductCommand = new AddProductCommand(validProduct);
         ModelStub modelStub = new ModelStubWithProduct(validProduct);
-
         assertThrows(CommandException.class, AddProductCommand.MESSAGE_DUPLICATE_PRODUCT, () ->
                 addProductCommand.execute(modelStub));
     }
@@ -60,9 +57,7 @@ public class AddProductCommandTest {
         Product productWithNonExistentSupplier = new ProductBuilder()
                 .withSupplierName("NonExistentSupplier")
                 .build();
-
         AddProductCommand addProductCommand = new AddProductCommand(productWithNonExistentSupplier);
-
         ModelStubWithoutSupplier modelStub = new ModelStubWithoutSupplier();
         assertThrows(CommandException.class, String.format(AddProductCommand.MESSAGE_SUPPLIER_NOT_FOUND,
                 "NonExistentSupplier"), () -> addProductCommand.execute(modelStub));
@@ -73,90 +68,72 @@ public class AddProductCommandTest {
         public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
             throw new AssertionError("This method should not be called.");
         }
-
         @Override
         public List<String> getAllTags() {
             throw new AssertionError("This method should not be called.");
         }
-
         @Override
         public boolean hasProduct(Product product) {
             throw new AssertionError("This method should not be called.");
         }
-
         @Override
         public void addProduct(Product product){ throw new AssertionError("This method should not be called."); }
-
         @Override
         public ReadOnlyUserPrefs getUserPrefs() {
             throw new AssertionError("This method should not be called.");
         }
-
         @Override
         public GuiSettings getGuiSettings() {
             throw new AssertionError("This method should not be called.");
         }
-
         @Override
         public void setGuiSettings(GuiSettings guiSettings) {
             throw new AssertionError("This method should not be called.");
         }
-
         @Override
         public Path getAddressBookFilePath() {
             throw new AssertionError("This method should not be called.");
         }
-
         @Override
         public void setAddressBookFilePath(Path addressBookFilePath) {
             throw new AssertionError("This method should not be called.");
         }
-
         @Override
         public void addSupplier(Supplier supplier) {
             throw new AssertionError("This method should not be called.");
         }
-
         @Override
         public void setAddressBook(ReadOnlyAddressBook newData) {
             throw new AssertionError("This method should not be called.");
         }
-
         @Override
         public ReadOnlyAddressBook getAddressBook() {
             throw new AssertionError("This method should not be called.");
         }
-
         @Override
         public boolean hasSupplier(Supplier supplier) {
             throw new AssertionError("This method should not be called.");
         }
-
         @Override
         public void deleteSupplier(Supplier target) {
             throw new AssertionError("This method should not be called.");
         }
-
         @Override
         public void deleteProduct(Product target) {
             throw new AssertionError("This method should not be called.");
         }
-
         @Override
         public void setSupplier(Supplier target, Supplier editedSupplier) {
             throw new AssertionError("This method should not be called.");
         }
-
         @Override
         public void setProduct(Product target, Product editedSupplier) {
             throw new AssertionError("This method should not be called.");
         }
-
         @Override
         public ObservableList<Supplier> getModifiedSupplierList() {
             throw new AssertionError("This method should not be called.");
         }
-
         @Override
         public void updateFilteredSupplierList(Predicate<Supplier> predicate) {
             throw new AssertionError("This method should not be called.");
@@ -165,17 +142,14 @@ public class AddProductCommandTest {
         public ObservableList<Product> getModifiedProductList() {
             throw new AssertionError("This method should not be called.");
         }
-
         @Override
         public void updateFilteredProductList(Predicate<Product> predicate) {
             throw new AssertionError("This method should not be called.");
         }
-
         @Override
         public void updateSortedProductList(Comparator<Product> predicate) {
             throw new AssertionError("This method should not be called.");
         }
-
         @Override
         public Product findProductByName(ProductName productName) {
             return null;
@@ -196,13 +170,11 @@ public class AddProductCommandTest {
      */
     private class ModelStubAcceptingProductAdded extends ModelStub {
         final ArrayList<Product> productsAdded = new ArrayList<>();
-
         @Override
         public boolean hasProduct(Product product) {
             requireNonNull(product);
             return productsAdded.stream().anyMatch(product::isSameProduct);
         }
-
         @Override
         public void addProduct(Product product) {
             requireNonNull(product);
@@ -215,12 +187,10 @@ public class AddProductCommandTest {
      */
     private class ModelStubWithProduct extends ModelStub {
         private final Product product;
-
         ModelStubWithProduct(Product product) {
             requireNonNull(product);
             this.product = product;
         }
-
         @Override
         public boolean hasProduct(Product product) {
             requireNonNull(product);
@@ -237,13 +207,11 @@ public class AddProductCommandTest {
      */
     private class ModelStubWithoutSupplier extends ModelStub {
         final ArrayList<Product> productsAdded = new ArrayList<>();
-
         @Override
         public boolean hasProduct(Product product) {
             requireNonNull(product);
             return productsAdded.stream().anyMatch(product::isSameProduct);
         }
-
         @Override
         public void addProduct(Product product) {
             requireNonNull(product);

--- a/src/test/java/seedu/address/logic/commands/AddProductCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddProductCommandTest.java
@@ -77,7 +77,9 @@ public class AddProductCommandTest {
             throw new AssertionError("This method should not be called.");
         }
         @Override
-        public void addProduct(Product product) { throw new AssertionError("This method should not be called."); }
+        public void addProduct(Product product) {
+            throw new AssertionError("This method should not be called.");
+        }
         @Override
         public ReadOnlyUserPrefs getUserPrefs() {
             throw new AssertionError("This method should not be called.");
@@ -110,6 +112,7 @@ public class AddProductCommandTest {
         public ReadOnlyAddressBook getAddressBook() {
             throw new AssertionError("This method should not be called.");
         }
+
         @Override
         public boolean hasSupplier(Supplier supplier) {
             throw new AssertionError("This method should not be called.");

--- a/src/test/java/seedu/address/logic/commands/AddProductCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddProductCommandTest.java
@@ -77,7 +77,7 @@ public class AddProductCommandTest {
             throw new AssertionError("This method should not be called.");
         }
         @Override
-        public void addProduct(Product product){ throw new AssertionError("This method should not be called."); }
+        public void addProduct(Product product) { throw new AssertionError("This method should not be called."); }
         @Override
         public ReadOnlyUserPrefs getUserPrefs() {
             throw new AssertionError("This method should not be called.");

--- a/src/test/java/seedu/address/logic/commands/AddProductCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddProductCommandTest.java
@@ -1,26 +1,16 @@
 package seedu.address.logic.commands;
 
-import static java.util.Objects.requireNonNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalSuppliers.ALICE;
-
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Predicate;
-
-import org.junit.jupiter.api.Test;
-
 import javafx.collections.ObservableList;
+import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
@@ -28,71 +18,56 @@ import seedu.address.model.product.Product;
 import seedu.address.model.product.ProductName;
 import seedu.address.model.supplier.Name;
 import seedu.address.model.supplier.Supplier;
-import seedu.address.testutil.SupplierBuilder;
+import seedu.address.testutil.ProductBuilder;
 
-public class AddSupplierCommandTest {
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
 
+public class AddProductCommandTest {
+
+    //null passed
     @Test
-    public void constructor_nullSupplier_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new AddSupplierCommand(null));
+    public void constructor_nullProduct_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AddProductCommand(null));
     }
 
+    //Product does not exist and supplier exists initially
     @Test
-    public void execute_supplierAcceptedByModel_addSuccessful() throws Exception {
-        ModelStubAcceptingSupplierAdded modelStub = new ModelStubAcceptingSupplierAdded();
-        Supplier validSupplier = new SupplierBuilder().build();
+    public void execute_productAcceptedByModel_addSuccessful() throws Exception {
+        ModelStubAcceptingProductAdded modelStub = new ModelStubAcceptingProductAdded();
+        Product validProduct = new ProductBuilder().build();
 
-        CommandResult commandResult = new AddSupplierCommand(validSupplier).execute(modelStub);
+        CommandResult commandResult = new AddProductCommand(validProduct).execute(modelStub);
 
-        assertEquals(String.format(AddSupplierCommand.MESSAGE_SUCCESS, Messages.format(validSupplier)),
+        assertEquals(String.format(AddProductCommand.MESSAGE_SUCCESS, Messages.format(validProduct)),
                 commandResult.getFeedbackToUser());
-        assertEquals(Arrays.asList(validSupplier), modelStub.suppliersAdded);
+        assertEquals(Arrays.asList(validProduct), modelStub.productsAdded);
     }
-
+    //Product exists initially
     @Test
-    public void execute_duplicateSupplier_throwsCommandException() {
-        Supplier validSupplier = new SupplierBuilder().build();
-        AddSupplierCommand addSupplierCommand = new AddSupplierCommand(validSupplier);
-        ModelStub modelStub = new ModelStubWithSupplier(validSupplier);
+    public void execute_duplicateProduct_throwsCommandException() {
+        Product validProduct = new ProductBuilder().build();
+        AddProductCommand addProductCommand = new AddProductCommand(validProduct);
+        ModelStub modelStub = new ModelStubWithProduct(validProduct);
 
-        assertThrows(CommandException.class, AddSupplierCommand.MESSAGE_DUPLICATE_SUPPLIER, () ->
-                addSupplierCommand.execute(modelStub));
+        assertThrows(CommandException.class, AddProductCommand.MESSAGE_DUPLICATE_PRODUCT, () ->
+                addProductCommand.execute(modelStub));
     }
-
+    //Supplier does not exist initially
     @Test
-    public void equals() {
-        Supplier alice = new SupplierBuilder().withName("Alice").build();
-        Supplier bob = new SupplierBuilder().withName("Bob").build();
-        AddSupplierCommand addAliceCommand = new AddSupplierCommand(alice);
-        AddSupplierCommand addBobCommand = new AddSupplierCommand(bob);
+    public void execute_nonExistentSupplier_throwsCommandException() {
+        Product productWithNonExistentSupplier = new ProductBuilder()
+                .withSupplierName("NonExistentSupplier")
+                .build();
 
-        // same object -> returns true
-        assertTrue(addAliceCommand.equals(addAliceCommand));
+        AddProductCommand addProductCommand = new AddProductCommand(productWithNonExistentSupplier);
 
-        // same values -> returns true
-        AddSupplierCommand addAliceCommandCopy = new AddSupplierCommand(alice);
-        assertTrue(addAliceCommand.equals(addAliceCommandCopy));
-
-        // different types -> returns false
-        assertFalse(addAliceCommand.equals(1));
-
-        // null -> returns false
-        assertFalse(addAliceCommand.equals(null));
-
-        // different supplier -> returns false
-        assertFalse(addAliceCommand.equals(addBobCommand));
+        ModelStubWithoutSupplier modelStub = new ModelStubWithoutSupplier();
+        assertThrows(CommandException.class, String.format(AddProductCommand.MESSAGE_SUPPLIER_NOT_FOUND,
+                "NonExistentSupplier"), () -> addProductCommand.execute(modelStub));
     }
 
-    @Test
-    public void toStringMethod() {
-        AddSupplierCommand addSupplierCommand = new AddSupplierCommand(ALICE);
-        String expected = AddSupplierCommand.class.getCanonicalName() + "{toAdd=" + ALICE + "}";
-        assertEquals(expected, addSupplierCommand.toString());
-    }
-
-    /**
-     * A default model stub that have all of the methods failing.
-     */
     private class ModelStub implements Model {
         @Override
         public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
@@ -213,49 +188,70 @@ public class AddSupplierCommandTest {
         @Override
         public boolean isProductAssignedToAnySupplier(Product product) {
             throw new AssertionError("This method should not be called.");
+        };
+    }
+
+    /**
+     * A Model stub that accepts any product being added.
+     */
+    private class ModelStubAcceptingProductAdded extends ModelStub {
+        final ArrayList<Product> productsAdded = new ArrayList<>();
+
+        @Override
+        public boolean hasProduct(Product product) {
+            requireNonNull(product);
+            return productsAdded.stream().anyMatch(product::isSameProduct);
+        }
+
+        @Override
+        public void addProduct(Product product) {
+            requireNonNull(product);
+            productsAdded.add(product);
+        }
+
+    }
+    /**
+     * A Model stub for testing duplicate products.
+     */
+    private class ModelStubWithProduct extends ModelStub {
+        private final Product product;
+
+        ModelStubWithProduct(Product product) {
+            requireNonNull(product);
+            this.product = product;
+        }
+
+        @Override
+        public boolean hasProduct(Product product) {
+            requireNonNull(product);
+            return this.product.isSameProduct(product);
+        }
+        @Override
+        public Supplier findSupplier(Name supplierName) {
+            return null;
         }
     }
 
     /**
-     * A Model stub that contains a single supplier.
+     * A Model stub for testing non-existent supplier scenarios.
      */
-    private class ModelStubWithSupplier extends ModelStub {
-        private final Supplier supplier;
+    private class ModelStubWithoutSupplier extends ModelStub {
+        final ArrayList<Product> productsAdded = new ArrayList<>();
 
-        ModelStubWithSupplier(Supplier supplier) {
-            requireNonNull(supplier);
-            this.supplier = supplier;
+        @Override
+        public boolean hasProduct(Product product) {
+            requireNonNull(product);
+            return productsAdded.stream().anyMatch(product::isSameProduct);
         }
 
         @Override
-        public boolean hasSupplier(Supplier supplier) {
-            requireNonNull(supplier);
-            return this.supplier.isSameSupplier(supplier);
+        public void addProduct(Product product) {
+            requireNonNull(product);
+            productsAdded.add(product);
+        }
+        @Override
+        public Supplier findSupplier(Name supplierName) {
+            return null; // Simulates a missing supplier by returning null.
         }
     }
-
-    /**
-     * A Model stub that always accept the supplier being added.
-     */
-    private class ModelStubAcceptingSupplierAdded extends ModelStub {
-        final ArrayList<Supplier> suppliersAdded = new ArrayList<>();
-
-        @Override
-        public boolean hasSupplier(Supplier supplier) {
-            requireNonNull(supplier);
-            return suppliersAdded.stream().anyMatch(supplier::isSameSupplier);
-        }
-
-        @Override
-        public void addSupplier(Supplier supplier) {
-            requireNonNull(supplier);
-            suppliersAdded.add(supplier);
-        }
-
-        @Override
-        public ReadOnlyAddressBook getAddressBook() {
-            return new AddressBook();
-        }
-    }
-
 }

--- a/src/test/java/seedu/address/logic/commands/AddSupplierCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddSupplierCommandTest.java
@@ -110,7 +110,9 @@ public class AddSupplierCommandTest {
         }
 
         @Override
-        public void addProduct(Product product){ throw new AssertionError("This method should not be called."); }
+        public void addProduct(Product product) {
+            throw new AssertionError("This method should not be called.");
+        }
 
         @Override
         public ReadOnlyUserPrefs getUserPrefs() {

--- a/src/test/java/seedu/address/logic/commands/AssignProductCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AssignProductCommandTest.java
@@ -24,6 +24,7 @@ import seedu.address.testutil.SupplierBuilder;
 
 public class AssignProductCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    //Successfully assign products to supplier
     @Test
     public void execute_assignProductToSupplier_success() throws Exception {
         Supplier supplier = new SupplierBuilder().withName(VALID_NAME_AMY).build();
@@ -47,6 +48,7 @@ public class AssignProductCommandTest {
         assertCommandSuccess(assignProductCommand, model, expectedMessage, expectedModel);
     }
 
+    //Supplier not found
     @Test
     public void execute_supplierNotFound_throwsCommandException() {
         Product product = new ProductBuilder().withName(VALID_PRODUCT_APPLE_PIE).build();
@@ -59,7 +61,7 @@ public class AssignProductCommandTest {
         assertCommandFailure(assignProductCommand, model, String.format(AssignProductCommand.MESSAGE_SUPPLIER_NOT_FOUND,
                 "Nonexistent Supplier"));
     }
-
+    //Product not found
     @Test
     public void execute_productNotFound_throwsCommandException() {
         Supplier supplier = new SupplierBuilder().withName(VALID_NAME_AMY).build();
@@ -72,7 +74,7 @@ public class AssignProductCommandTest {
         assertCommandFailure(assignProductCommand, model, String.format(AssignProductCommand.MESSAGE_PRODUCT_NOT_FOUND,
                 "Nonexistent Product"));
     }
-
+    //Product is already assigned to same supplier
     @Test
     public void execute_productAlreadyAssigned_throwsCommandException() {
         Product product = new ProductBuilder()
@@ -93,7 +95,7 @@ public class AssignProductCommandTest {
 
         assertCommandFailure(assignProductCommand, model, AssignProductCommand.MESSAGE_PRODUCT_ALREADY_ASSIGNED);
     }
-
+    //Product is already assigned to a different supplier
     @Test
     public void execute_productAssignedToDifferentSupplier_throwsCommandException() {
 

--- a/src/test/java/seedu/address/logic/commands/UnassignProductCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnassignProductCommandTest.java
@@ -8,6 +8,7 @@ import static seedu.address.testutil.TypicalSuppliers.getTypicalAddressBook;
 
 import java.util.Collections;
 import java.util.Set;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/commands/UnassignProductCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnassignProductCommandTest.java
@@ -3,10 +3,15 @@ package seedu.address.logic.commands;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PRODUCT_APPLE_PIE;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalSuppliers.getTypicalAddressBook;
 
+import java.util.Collections;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -17,8 +22,14 @@ import seedu.address.testutil.ProductBuilder;
 import seedu.address.testutil.SupplierBuilder;
 
 public class UnassignProductCommandTest {
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model model;
 
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    }
+
+    //Product not found
     @Test
     public void execute_productNotFound_throwsCommandException() {
         Supplier supplier = new SupplierBuilder().withName(VALID_NAME_AMY).build();
@@ -32,6 +43,7 @@ public class UnassignProductCommandTest {
                 "Nonexistent Product"));
     }
 
+    //Product is found, but not assigned
     @Test
     public void execute_productNotAssigned_throwsCommandException() {
         Supplier supplier = new SupplierBuilder().withName(VALID_NAME_AMY).build();
@@ -44,5 +56,26 @@ public class UnassignProductCommandTest {
                 new ProductName(VALID_PRODUCT_APPLE_PIE));
 
         assertCommandFailure(unassignProductCommand, model, UnassignProductCommand.MESSAGE_PRODUCT_NOT_ASSIGNED);
+    }
+
+    //Product is assigned and found successfully
+    @Test
+    public void execute_productAssignedAndFound_success() {
+        Product product = new ProductBuilder().withName(VALID_PRODUCT_APPLE_PIE).withSupplierName(VALID_NAME_AMY)
+                .build();
+        Supplier supplier = new SupplierBuilder().withName(VALID_NAME_AMY).withProducts(Set.of(product)).build();
+        model.addSupplier(supplier);
+        model.addProduct(product);
+        UnassignProductCommand unassignProductCommand = new UnassignProductCommand(new
+                ProductName(VALID_PRODUCT_APPLE_PIE));
+        String expectedMessage = String.format(UnassignProductCommand.MESSAGE_SUCCESS,
+                VALID_PRODUCT_APPLE_PIE, VALID_NAME_AMY);
+        Product updatedProduct = new ProductBuilder().withName(VALID_PRODUCT_APPLE_PIE).build();
+        Supplier updatedSupplier = new SupplierBuilder().withName(VALID_NAME_AMY).withProducts(
+                Collections.emptySet()).build();
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setProduct(product, updatedProduct);
+        expectedModel.setSupplier(supplier, updatedSupplier);
+        assertCommandSuccess(unassignProductCommand, model, expectedMessage, expectedModel);
     }
 }


### PR DESCRIPTION
Adding a product will throw an exception if the supplier assigned does not exist.
<img width="955" alt="image" src="https://github.com/user-attachments/assets/884e8656-88cb-45c5-b6c1-cef23f618588">

Added assertions in unassign and assign product commands to ensure that when supplier name is stored in product, the same product is also stored in productlist of suppliers. 
<img width="535" alt="image" src="https://github.com/user-attachments/assets/ca78dd19-9b39-45cb-98e2-1f3e438d79c3">

Fixes #198 and #205