### PR TITLE
Update UG, DG and Delete classes

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -375,6 +375,10 @@ Preconditions:
 
     Use case ends.
 
+Additional notes:
+* After performing a delete supplier operation, the Inventory Manager must manually refresh the view to see the changes
+  to supplier-product relations. This can be done by <ins>viewing the products</ins>.
+
 **Extensions**
 
 * 1a. Product/Supplier name is in invalid format:
@@ -498,18 +502,32 @@ testers are expected to do more *exploratory* testing.
 
 1. Deleting a supplier while all suppliers are being shown
 
-   1. Prerequisites: List all suppliers using the `list` command. Multiple suppliers in the list.
+    1. Prerequisites:
+        * View all suppliers using the `view_supplier` command.
+        * Ensure that there are multiple suppliers in the list.
 
-   1. Test case: `delete 1`<br>
-      Expected: First contact is deleted from the list. Details of the deleted contact shown in the status message. Timestamp in the status bar is updated.
+    1. Test case 1: `delete_supplier n/Supplier Name`<br>
+        * Description: Delete a supplier using a valid unique name.
+        * Expected:
+            * The specified supplier is deleted from the supplier list.
+            * Any supplier-product relationships involving this supplier are removed.
+            * Use the `view_product` command to verify that products that were assigned the deleted supplier now have no assigned supplier
+            * Details of the deleted supplier are shown in the success message.
 
-   1. Test case: `delete 0`<br>
-      Expected: No supplier is deleted. Error details shown in the status message. Status bar remains the same.
+    1. Test case 2: `delete_supplier n/R@chel`<br>
+        * Description: Attempt to delete a supplier with an invalid name format containing special characters.
+        * Expected:
+            * No supplier is deleted.
+            * An error message is displayed indicating the invalid supplier name format.
 
-   1. Other incorrect delete commands to try: `delete`, `delete x`, `...` (where x is larger than the list size)<br>
-      Expected: Similar to previous.
+    1. Test case 3: `delete_supplier n/NonexistentSupplier`<br>
+        * Description: Attempt to delete a supplier that does not exist in the system.
+        * Expected:
+            * No supplier is deleted.
+            * An error message is displayed indicating that the supplier does not exist.
 
-1. _{ more test cases …​ }_
+1. Other incorrect delete commands to try: `delete`, `delete_supplier x/`, `...` (where x is larger than the list size)<br>
+   Expected: Similar to previous.
 
 ### Saving data
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -422,6 +422,8 @@ Here are a few examples to help you:
     <strong>⚠️ Important:</strong>
     <ul>
         <li>Products should already exist in the system, otherwise errors are displayed.</li>
+        <li>When deleting an existing supplier, any products that have been assigned this deleted supplier will have their assigned supplier removed. However, you will need to use the `view_product` command for the application to reflect this change.
+</li>
     </ul>
 </div>
 

--- a/src/main/java/seedu/address/logic/parser/DeleteProductCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteProductCommandParser.java
@@ -1,6 +1,6 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_NAME;
 
 import seedu.address.logic.commands.DeleteProductCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -18,12 +18,12 @@ public class DeleteProductCommandParser implements Parser<DeleteProductCommand> 
      */
     public DeleteProductCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME);
-        ParserUtil.verifyInput(argMultimap, new Prefix[]{PREFIX_NAME},
+                ArgumentTokenizer.tokenize(args, PREFIX_PRODUCT_NAME);
+        ParserUtil.verifyInput(argMultimap, new Prefix[]{PREFIX_PRODUCT_NAME},
                 DeleteProductCommand.MESSAGE_USAGE);
         argMultimap.verifyNoDuplicatePrefixesFor(
-                PREFIX_NAME);
-        ProductName productName = ParserUtil.parseProductName(argMultimap.getValue(PREFIX_NAME).get());
+                PREFIX_PRODUCT_NAME);
+        ProductName productName = ParserUtil.parseProductName(argMultimap.getValue(PREFIX_PRODUCT_NAME).get());
 
         return new DeleteProductCommand(productName);
     }

--- a/src/main/java/seedu/address/logic/parser/DeleteSupplierCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteSupplierCommandParser.java
@@ -1,6 +1,6 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SUPPLIER_NAME;
 
 import seedu.address.logic.commands.DeleteSupplierCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -18,12 +18,12 @@ public class DeleteSupplierCommandParser implements Parser<DeleteSupplierCommand
      */
     public DeleteSupplierCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME);
-        ParserUtil.verifyInput(argMultimap, new Prefix[]{PREFIX_NAME},
+                ArgumentTokenizer.tokenize(args, PREFIX_SUPPLIER_NAME);
+        ParserUtil.verifyInput(argMultimap, new Prefix[]{PREFIX_SUPPLIER_NAME},
                 DeleteSupplierCommand.MESSAGE_USAGE);
         argMultimap.verifyNoDuplicatePrefixesFor(
-                PREFIX_NAME);
-        Name supplierName = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+                PREFIX_SUPPLIER_NAME);
+        Name supplierName = ParserUtil.parseName(argMultimap.getValue(PREFIX_SUPPLIER_NAME).get());
 
         return new DeleteSupplierCommand(supplierName);
     }

--- a/src/main/java/seedu/address/model/product/Product.java
+++ b/src/main/java/seedu/address/model/product/Product.java
@@ -70,7 +70,7 @@ public class Product {
      * Removes assigned supplier if is supplied by the specified supplier.
      */
     public void removeSupplier(Name supplierName) {
-        if (supplierName != null && this.supplierName != null && this.supplierName.equals(supplierName)) {
+        if (this.supplierName != null && this.supplierName.equals(supplierName)) {
             this.supplierName = null;
         }
     }


### PR DESCRIPTION
Delete commands have their prefixes changed from 'n/' to 'pr/' and 'su/' for deleting products and suppliers respectively. This is to fix a bug where delete commands do not work with autocomplete due to having 'n/' as the prefix.

Updated UG and DG for delete commands.